### PR TITLE
Enhance dashboard filters and layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,34 @@
+body {
+    font-family: "Open Sans", "Roboto", "Helvetica Neue", sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.controls > div {
+    margin-bottom: 15px;
+}
+
+.kpi-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+.kpi-table th,
+.kpi-table td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    text-align: left;
+}
+.kpi-table tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+
+.graph-wrapper {
+    margin-bottom: 30px;
+}


### PR DESCRIPTION
## Summary
- add CSS styling for layout and typography
- implement KPI table with metric details
- support bus selection filtered by voltage
- format Tswitch slider marks
- add hover details with case/bus/run data

## Testing
- `ruff check dashboard.py data_model.py`
- `black dashboard.py data_model.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688895ee4aac83298fe3597440410bef