### PR TITLE
Fix dashboard callbacks and restore missing graphs

### DIFF
--- a/data_model.py
+++ b/data_model.py
@@ -447,3 +447,28 @@ def get_ll_undervoltage(
         aggfunc="max",
     )
     return pivot.sort_index()
+
+
+def initial_voltage_by_case(filters: Optional[Dict[str, Iterable]] = None) -> pd.Series:
+    """Return maximum initial voltage indexed by ``Case_Bus``."""
+    df = get_data()
+    df_filtered = _apply_filters(df, filters)
+    value_col = "V0 [pu]" if "V0 [pu]" in df_filtered.columns else "LLs [pu]"
+    ser = df_filtered.groupby("Case_Bus")[value_col].max()
+    return ser.sort_index()
+
+
+def lg_uv_by_case(filters: Optional[Dict[str, Iterable]] = None) -> pd.Series:
+    """Return maximum single-phase RMS undervoltage indexed by ``Case_Bus``."""
+    df = get_data()
+    df_filtered = _apply_filters(df, filters)
+    ser = df_filtered.groupby("Case_Bus")["LG_UV"].max()
+    return ser.sort_index()
+
+
+def ll_uv_by_case(filters: Optional[Dict[str, Iterable]] = None) -> pd.Series:
+    """Return maximum line-to-line RMS undervoltage indexed by ``Case_Bus``."""
+    df = get_data()
+    df_filtered = _apply_filters(df, filters)
+    ser = df_filtered.groupby("Case_Bus")["LL_UV"].max()
+    return ser.sort_index()


### PR DESCRIPTION
## Summary
- add case-level helpers for initial voltage and undervoltage metrics
- update dashboard graph titles and add functions for case-level figures
- make x‑axis toggle work and limit to first five graphs
- clean up unused imports

## Testing
- `ruff check .`
- `black dashboard.py data_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888aa8929fc832981eef2ebbc4023c4