### PR TITLE
Implement manual refresh and x‑axis toggle

### DIFF
--- a/data_model.py
+++ b/data_model.py
@@ -88,6 +88,13 @@ def get_data() -> pd.DataFrame:
     return df
 
 
+def refresh_data() -> None:
+    """Clear cached data and filter options."""
+    get_data.cache_clear()
+    get_filter_options.cache_clear()
+    _cached_bus_names.cache_clear()
+
+
 def _apply_filters(
     df: pd.DataFrame, filters: Optional[Dict[str, Iterable]] = None
 ) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- add refresh button to re-read data and trigger callbacks
- remove Run# selector from layout
- allow LG/LL undervoltage graphs to use x-axis toggle
- provide `refresh_data` helper in data_model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d76775f4832999fdde67de2c3960