### PR TITLE
Improve Tswitch filtering and callback updates

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -289,7 +289,7 @@ def main() -> None:
     app.title = "Overvoltage Dashboard"
     app.layout = build_layout()
 
-    # ------------ NEW CALLBACKS ------------
+    # -------- NEW CALLBACKS --------
 
     # 1. Disable/enable the Tswitch slider depending on the chosen X-axis
     @app.callback(
@@ -409,13 +409,24 @@ def main() -> None:
         df = dm.get_data()
         df_filtered = dm._apply_filters(df, filters)
 
-        # Only slice by Tswitch when Tswitch is actually on the X-axis.
-        if xaxis_choice == "Run#":
-            df_range = df_filtered
-        else:
+        # Cast Run# to int for cleaner X-axis values
+        if "Run#" in df_filtered.columns:
+            df_filtered["Run#"] = df_filtered["Run#"].astype(int)
+
+        # Apply Tswitch slice **only** when Tswitch is the chosen X-axis
+        if (
+            xaxis_choice == "Tswitch_a [s]"
+            and tswitch_range
+            and isinstance(tswitch_range, (list, tuple))
+            and len(tswitch_range) == 2
+        ):
             df_range = df_filtered[
-                df_filtered["Tswitch_a [s]"].between(tswitch_range[0], tswitch_range[1])
+                df_filtered["Tswitch_a [s]"].between(
+                    tswitch_range[0], tswitch_range[1]
+                )
             ]
+        else:
+            df_range = df_filtered
         if df_range.empty:
             return (
                 create_kpi_table([]),

--- a/data_model.py
+++ b/data_model.py
@@ -79,6 +79,10 @@ def get_data() -> pd.DataFrame:
     # Construct composite key for column dimension
     df["Case_Bus"] = df["Case name"].astype(str) + "_" + df["Bus name"].astype(str)
 
+    # Normalise the Run column so downstream code can safely treat it as an integer
+    if "Run#" in df.columns:
+        df["Run#"] = df["Run#"].astype(int)
+
     # Pre-compute undervoltage columns used in several graphs
     if "LGr [pu]" in df.columns:
         df["LG_UV"] = 1 - df["LGr [pu]"]


### PR DESCRIPTION
## Summary
- adjust Tswitch filtering so ranges are applied only when needed
- ensure Run# column uses integer dtype
- update callbacks section comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3f78c1388329839a9a4fa87a8da6